### PR TITLE
Add course property tips

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "murmurhash-js": "^1.0.0",
     "pako": "^1.0.11",
     "promise-worker": "^2.0.1",
-    "shu-course-number-parser": "^0.1.0",
+    "shu-course-number-parser": "^0.2.0",
     "v-viewer": "~1.7.0",
     "vue": "^2.7.14",
     "vue-clipboard2": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "murmurhash-js": "^1.0.0",
     "pako": "^1.0.11",
     "promise-worker": "^2.0.1",
+    "shu-course-number-parser": "^0.1.0",
     "v-viewer": "~1.7.0",
     "vue": "^2.7.14",
     "vue-clipboard2": "^0.3.3",

--- a/src/mixins/LookupPanel.js
+++ b/src/mixins/LookupPanel.js
@@ -158,6 +158,9 @@ export const LookupConditionsMixin = {
           'teacher_name': '',
           'class_time': '',
           'campus': '',
+          'class_sort_college': '{"name":""}',
+          'class_sort_major': '{"name":""}',
+          'class_sort_property': '{"name":""}',
         },
         filterLimitations: {
           'xian_zhi_ren_shu': 'default',

--- a/src/mixins/common/getCourseClassList.js
+++ b/src/mixins/common/getCourseClassList.js
@@ -1,0 +1,9 @@
+import { getCollegesList, getMajorsList, getLessonPropertiesList } from "shu-course-number-parser";
+
+export const GetCourseClassListMixin = {
+  methods: {
+    getCollegesList: (p) => getCollegesList(p),
+    getMajorsList: (v, p) => getMajorsList(v, p),
+    getLessonPropertiesList: () => getLessonPropertiesList(),
+  }
+}

--- a/src/mixins/common/getCourseProperty.js
+++ b/src/mixins/common/getCourseProperty.js
@@ -1,0 +1,16 @@
+import { getLessonCollegeOrMajor, getLessonProperty } from "shu-course-number-parser";
+
+export const GetCoursePropertyMixin = {
+  methods: {
+    getCourseProperty: (v) => getLessonProperty(v),
+    getCourseInfo: (v, showProperty = true) => {
+      let out = [];
+      if (showProperty) out.push(getLessonProperty(v));
+      out.push(getLessonCollegeOrMajor(v, "major"));
+      out.push(getLessonCollegeOrMajor(v, "college"));
+      out = out.filter(v => v !== '');
+      return out.join(", ");
+    },
+    getLessonCollegeOrMajor: (id, type) => getLessonCollegeOrMajor(id, type),
+  },
+}

--- a/src/pages/index/components/LookupPanel/LookupConditions.vue
+++ b/src/pages/index/components/LookupPanel/LookupConditions.vue
@@ -35,6 +35,24 @@
           <a-select-option value="延长">延长</a-select-option>
         </a-select>
       </a-form-item>
+      <a-form-item label="学院">
+        <a-select v-model="conditions.search['class_sort_college']"  class="w-200px">
+          <a-select-option value='{"name":""}'>全部</a-select-option>
+          <a-select-option v-for="item in getCollegesList()" :key="item.name" :value="JSON.stringify({name:item.name,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+        </a-select>
+      </a-form-item>
+      <a-form-item label="专业">
+        <a-select v-model="conditions.search['class_sort_major']"  class="w-200px">
+          <a-select-option value='{"name":""}'>全部</a-select-option>
+          <a-select-option v-for="item in getMajorsList(JSON.parse(conditions.search['class_sort_college']).name)" :key="item.name" :value="JSON.stringify({name:item.name,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+        </a-select>
+      </a-form-item>
+      <a-form-item label="课程属性">
+        <a-select v-model="conditions.search['class_sort_property']"  class="w-200px">
+          <a-select-option value='{"name":""}'>全部</a-select-option>
+          <a-select-option v-for="item in getLessonPropertiesList()" :key="item.name" :value="JSON.stringify({name:item.name,code:item.code,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+        </a-select>
+      </a-form-item>
       <a-form-item label="筛除时间冲突选项">
         <a-switch checked-children="是" un-checked-children="否" v-model="conditions.filterConflicts" />
       </a-form-item>
@@ -108,11 +126,12 @@
 
 <script>
   import { LookupConditionsMixin } from '../../../../mixins/LookupPanel';
+  import { GetCourseClassListMixin } from '../../../../mixins/common/getCourseClassList';
 
 
   export default {
     name: 'LookupConditions',
-    mixins: [LookupConditionsMixin],
+    mixins: [LookupConditionsMixin, GetCourseClassListMixin],
   };
 </script>
 

--- a/src/pages/index/components/LookupPanel/index.vue
+++ b/src/pages/index/components/LookupPanel/index.vue
@@ -24,7 +24,7 @@
           </a>
           <a-badge :count="`${course.credit} 学分`" class="credit-badge" />
           <br />
-          <small class="id-info">{{ course.id }}</small>
+          <small class="id-info" :title="getCourseInfo(course.id)">{{ course.id }}</small>
         </template>
       </a-table-column>
       <a-table-column data-index="teacher" title="教师">
@@ -190,6 +190,7 @@
   import { conflictSolvingMixin } from '../../../../mixins/common/conflictsSolver';
   import { introductionOpenerMixin } from '../../../../mixins/common/introductionOpener';
   import { LookupPanelMixin } from '../../../../mixins/LookupPanel';
+  import { GetCoursePropertyMixin } from '../../../../mixins/common/getCourseProperty';
   import LookupConditions from './LookupConditions';
   import NumberCapacity from './NumberCapacity';
 
@@ -200,7 +201,7 @@
       NumberCapacity,
       LookupConditions,
     },
-    mixins: [introductionOpenerMixin, conflictSolvingMixin, LookupPanelMixin],
+    mixins: [introductionOpenerMixin, conflictSolvingMixin, LookupPanelMixin, GetCoursePropertyMixin],
   };
 </script>
 

--- a/src/pages/index/components/ReservedClassesList/CourseMeta.vue
+++ b/src/pages/index/components/ReservedClassesList/CourseMeta.vue
@@ -4,7 +4,7 @@
     <NumberCapacity :class-key="`${id}-${selectedClassKey}`" class="number-capacity" slot="actions"
                     v-if="selectedClassKey !== null && !expanded" />
     <span class="course-name">{{ course.courseName }}</span>{{ ' ' }}
-    <small class="course-id">({{ id }})</small>
+    <small class="course-id">{{ id }}{{ expanded ? ` ${getCourseInfo(id)}` : `` }}</small>
     <a :href="getLinkHref(id)" :title="getLinkTitle(course, id)"
        @click.stop="showCourseIntroduction($event, getLinkHref(id))" class="course-link course-intro-link"
        rel="external nofollow" target="_blank">简介</a>
@@ -26,6 +26,10 @@
       <a-divider type="vertical" />
       <small class="selected-info">
         {{ course.classes[selectedClassKey].classTime }}
+      </small>
+      <a-divider type="vertical" />
+      <small class="selected-info" :title="getCourseInfo(id,false)">
+        {{ getCourseProperty(id) }}
       </small>
       <a-divider type="vertical" />
       <small class="selected-info">
@@ -61,6 +65,7 @@
   import { introductionOpenerMixin } from '../../../../mixins/common/introductionOpener';
   import { CourseMetaMixin } from '../../../../mixins/ReservedClassesList';
   import { CopyCourseIdMixin } from '../../../../mixins/common/copyCourseId'
+  import { GetCoursePropertyMixin } from '../../../../mixins/common/getCourseProperty';
   import NumberCapacity from './NumberCapacity';
   import CourseColor from './CourseColor'
 
@@ -82,7 +87,7 @@
         type: Boolean,
       },
     },
-    mixins: [introductionOpenerMixin, CourseMetaMixin, CopyCourseIdMixin],
+    mixins: [introductionOpenerMixin, CourseMetaMixin, CopyCourseIdMixin, GetCoursePropertyMixin],
   };
 </script>
 

--- a/src/pages/index/components/ReservedClassesList/NumberCapacity.vue
+++ b/src/pages/index/components/ReservedClassesList/NumberCapacity.vue
@@ -2,7 +2,7 @@
   <div>
     <sup><strong>{{ extra.number }}</strong></sup>
     <span></span>
-    <sub>{{ extra.capacity }}人</sub>
+    <sub>{{ extra.capacity }} 人</sub>
   </div>
 </template>
 

--- a/src/pages/index/components/ScheduleTable/ClassCard.vue
+++ b/src/pages/index/components/ScheduleTable/ClassCard.vue
@@ -29,7 +29,7 @@
         type: Boolean,
       },
       theme: {
-        type: Number
+        type: String,
       }
     },
     mixins: [ClassCardMixin],

--- a/src/pages/m/components/LookupPanel/LookupConditions.vue
+++ b/src/pages/m/components/LookupPanel/LookupConditions.vue
@@ -56,9 +56,39 @@
           </a-form-item>
         </a-col>
       </a-row>
-      <a-form-item label="容量至少剩余">
-        <a-input-number :max="9999" :min="0" class="w-80px" placeholder="不限" v-model.number="conditions.number" />
-      </a-form-item>
+      <a-row>
+        <a-col :xs="11">
+          <a-form-item label="学院">
+            <a-select v-model="conditions.search['class_sort_college']"  class="w-200px">
+              <a-select-option value='{"name":""}'>全部</a-select-option>
+              <a-select-option v-for="item in getCollegesList()" :key="item.name" :value="JSON.stringify({name:item.name,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+            </a-select>
+          </a-form-item>
+        </a-col>
+        <a-col :xs="{offset: 2, span: 11}">
+          <a-form-item label="专业">
+            <a-select v-model="conditions.search['class_sort_major']"  class="w-200px">
+              <a-select-option value='{"name":""}'>全部</a-select-option>
+              <a-select-option v-for="item in getMajorsList(JSON.parse(conditions.search['class_sort_college']).name)" :key="item.name" :value="JSON.stringify({name:item.name,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+            </a-select>
+          </a-form-item>
+        </a-col>
+      </a-row>
+      <a-row>
+        <a-col :xs="11">
+          <a-form-item label="课程属性">
+            <a-select v-model="conditions.search['class_sort_property']"  class="w-200px">
+              <a-select-option value='{"name":""}'>全部</a-select-option>
+              <a-select-option v-for="item in getLessonPropertiesList()" :key="item.name" :value="JSON.stringify({name:item.name,code:item.code,regex:item.regex.toString()})">{{item.name}}</a-select-option>
+            </a-select>
+          </a-form-item>
+        </a-col>
+        <a-col :xs="{offset: 2, span: 11}">
+          <a-form-item label="容量至少剩余">
+            <a-input-number :max="9999" :min="0" class="w-200px" placeholder="不限" v-model.number="conditions.number" />
+          </a-form-item>
+        </a-col>
+      </a-row>
       <a-form-item label="显示选项">
         <a-radio-group button-style="solid" v-model="conditions.displayOption">
           <a-radio-button :value="0">全部</a-radio-button>
@@ -125,11 +155,12 @@
 
 <script>
   import { LookupConditionsMixin } from '../../../../mixins/LookupPanel';
+  import { GetCourseClassListMixin } from '../../../../mixins/common/getCourseClassList';
 
 
   export default {
     name: 'LookupConditions',
-    mixins: [LookupConditionsMixin],
+    mixins: [LookupConditionsMixin, GetCourseClassListMixin],
   };
 </script>
 

--- a/src/pages/m/components/LookupPanel/index.vue
+++ b/src/pages/m/components/LookupPanel/index.vue
@@ -16,8 +16,8 @@
         <!--suppress JSUnresolvedVariable -->
         <a-list-item slot="renderItem" slot-scope="course">
           <h3>
-            {{ course['course_name'] }} <small>({{ course['course_id'] }})</small>
-            <a-badge :count="`${course.credit}学分`" class="credit-badge" />
+            {{ course['course_name'] }} <small>{{ course['course_id'] }}</small>
+            <a-badge :count="`${course.credit} 学分`" class="credit-badge" />
           </h3>
           <h4>{{ course['teacher_name'] }}
             <small>({{
@@ -35,6 +35,12 @@
             {{ course['campus'] }}
             <a-divider type="vertical" />
             {{ $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).venue }}
+            <br />
+            {{ getCourseProperty(course['course_id']) }}
+            <a-divider type="vertical" />
+            {{ getLessonCollegeOrMajor(course['course_id'], "major") }}
+            <a-divider type="vertical" />
+            {{ getLessonCollegeOrMajor(course['course_id'], "college") }}
             <br
               v-if="($store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).date && $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).date !== '不开') || $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).limitations.length > 0" />
             <a-tag
@@ -140,6 +146,7 @@
 <script>
 import {conflictSolvingMixin} from '../../../../mixins/common/conflictsSolver';
 import {LookupPanelMixin} from '../../../../mixins/LookupPanel';
+import { GetCoursePropertyMixin } from '../../../../mixins/common/getCourseProperty';
 import LookupConditions from './LookupConditions';
 
 
@@ -148,7 +155,7 @@ export default {
     components: {
       LookupConditions,
     },
-    mixins: [conflictSolvingMixin, LookupPanelMixin],
+    mixins: [conflictSolvingMixin, LookupPanelMixin, GetCoursePropertyMixin],
     data() {
       return {
         pagination: {

--- a/src/pages/m/components/LookupPanel/index.vue
+++ b/src/pages/m/components/LookupPanel/index.vue
@@ -37,9 +37,9 @@
             {{ $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).venue }}
             <br />
             {{ getCourseProperty(course['course_id']) }}
-            <a-divider type="vertical" />
+            <a-divider v-if="getLessonCollegeOrMajor(course['course_id'], 'major') !== ''" type="vertical" />
             {{ getLessonCollegeOrMajor(course['course_id'], "major") }}
-            <a-divider type="vertical" />
+            <a-divider v-if="getLessonCollegeOrMajor(course['course_id'], 'college') !== ''" type="vertical" />
             {{ getLessonCollegeOrMajor(course['course_id'], "college") }}
             <br
               v-if="($store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).date && $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).date !== '不开') || $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).limitations.length > 0" />

--- a/src/pages/m/components/LookupPanel/index.vue
+++ b/src/pages/m/components/LookupPanel/index.vue
@@ -29,8 +29,8 @@
           <div class="course-info">
             {{ course['class_time'] }}
             <a-divider type="vertical" />
-            {{ $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).number }}/{{
-            $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).capacity }}人
+            {{ $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).number }} / {{
+            $store.getters.extra(`${course['course_id']}-${course['teacher_id']}`).capacity }} 人
             <br />
             {{ course['campus'] }}
             <a-divider type="vertical" />

--- a/src/pages/m/components/ReservedClassesList/CourseMeta.vue
+++ b/src/pages/m/components/ReservedClassesList/CourseMeta.vue
@@ -2,7 +2,7 @@
   <div :class="{ 'course-meta': true, 'course-meta-all-conflicted': allConflicted }">
     <a-badge :count="`${course.credit} 学分`" class="credit-badge" />
     <span class="course-name">{{ course.courseName }}</span>{{ ' ' }}
-    <small>({{ id }})</small>
+    <small>{{ id }}{{ expanded ? ` ${getCourseInfo(id)}` : `` }}</small>
     <template v-if="selectedClassKey !== null && !expanded">
       <br />
       <CourseColor :course-id="id" :course-name="course.courseName" />
@@ -19,6 +19,14 @@
       <a-divider type="vertical" />
       <small class="selected-info">
         {{ course.classes[selectedClassKey].classTime }}
+      </small>
+      <a-divider type="vertical" />
+      <small class="selected-info">
+        {{ getCourseProperty(id) }}
+      </small>
+      <a-divider v-if="getCourseInfo(id, false) !== ''" type="vertical" />
+      <small v-if="getCourseInfo(id, false) !== ''" class="selected-info">
+        {{ getCourseInfo(id, false) }}
       </small>
       <a-divider type="vertical" />
       <small class="selected-info">
@@ -52,6 +60,7 @@
 
 <script>
   import { CourseMetaMixin } from '../../../../mixins/ReservedClassesList';
+  import { GetCoursePropertyMixin } from '../../../../mixins/common/getCourseProperty';
   import NumberCapacity from './NumberCapacity';
   import CourseColor from './CourseColor'
 
@@ -73,7 +82,7 @@
         type: Boolean,
       },
     },
-    mixins: [CourseMetaMixin],
+    mixins: [CourseMetaMixin, GetCoursePropertyMixin],
   };
 </script>
 

--- a/src/pages/m/components/ScheduleTable/ClassCard.vue
+++ b/src/pages/m/components/ScheduleTable/ClassCard.vue
@@ -32,7 +32,7 @@
         default: false,
       },
       theme: {
-        type: Number,
+        type: String,
       }
     },
     mixins: [ClassCardMixin],

--- a/src/workers/filter.js
+++ b/src/workers/filter.js
@@ -2,7 +2,7 @@ import registerPromiseWorker from 'promise-worker/register';
 import { getPeriods } from '../utils';
 
 
-function concatRegExp(parts) {
+function concatRegExp (parts) {
   parts.forEach((part, index) => {
     parts[index] = part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   });
@@ -112,7 +112,13 @@ registerPromiseWorker(function (message) {
   let conditionsRegExp = {};
   for (let condition in message.conditions.search) {
     if (message.conditions.search.hasOwnProperty(condition)) {
-      if (message.conditions.regexpMode) {
+      if (condition.startsWith('class_sort')) {
+        if (JSON.parse(message.conditions.search[condition]).name !== '') {
+          // eslint-disable-next-line no-console
+          console.log('adding condition', condition, JSON.parse(message.conditions.search[condition]).name, JSON.parse(message.conditions.search[condition]).regex);
+          conditionsRegExp[condition] = new RegExp(JSON.parse(message.conditions.search[condition]).regex.slice(1, -1));
+        }
+      } else if (message.conditions.regexpMode) {
         try {
           conditionsRegExp[condition] = new RegExp(message.conditions.search[condition], 'i');
         } catch (e) {
@@ -135,7 +141,11 @@ registerPromiseWorker(function (message) {
     }
     for (let condition in conditionsRegExp) {
       if (conditionsRegExp.hasOwnProperty(condition)) {
-        if (!conditionsRegExp[condition].test(row[condition])) {
+        if (condition.startsWith('class_sort')) {
+          if (conditionsRegExp[condition] && !conditionsRegExp[condition].test(row['course_id'])) {
+            return;
+          }
+        } else if (!conditionsRegExp[condition].test(row[condition])) {
           return;
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11573,6 +11573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shu-course-number-parser@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "shu-course-number-parser@npm:0.1.0"
+  checksum: 994daa63fd42e86d2ca4d22742a613db44af0be7da3a4222369732553729ad59f47091aa89cf18e3fc71c33bbea0d76ee078a97e1c4253eb05ebfc6d0d39032a
+  languageName: node
+  linkType: hard
+
 "shu-scheduling-helper-frontend@workspace:.":
   version: 0.0.0-use.local
   resolution: "shu-scheduling-helper-frontend@workspace:."
@@ -11599,6 +11606,7 @@ __metadata:
     murmurhash-js: ^1.0.0
     pako: ^1.0.11
     promise-worker: ^2.0.1
+    shu-course-number-parser: ^0.1.0
     v-viewer: ~1.7.0
     vue: ^2.7.14
     vue-cli-plugin-ant-design: ^1.0.1
@@ -12654,11 +12662,11 @@ __metadata:
 
 "typescript@patch:typescript@^4.6.4#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11573,10 +11573,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shu-course-number-parser@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "shu-course-number-parser@npm:0.1.0"
-  checksum: 994daa63fd42e86d2ca4d22742a613db44af0be7da3a4222369732553729ad59f47091aa89cf18e3fc71c33bbea0d76ee078a97e1c4253eb05ebfc6d0d39032a
+"shu-course-number-parser@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "shu-course-number-parser@npm:0.2.0"
+  checksum: 95dde18c822ceafee92eff8d48bd74fb8778d31b292584a983e0581dfe2b0aec126f889e9704bf1cb1bf1dff7cdf74ff3e93c63a360c4a58fff6bf833e08ac96
   languageName: node
   linkType: hard
 
@@ -11606,7 +11606,7 @@ __metadata:
     murmurhash-js: ^1.0.0
     pako: ^1.0.11
     promise-worker: ^2.0.1
-    shu-course-number-parser: ^0.1.0
+    shu-course-number-parser: ^0.2.0
     v-viewer: ~1.7.0
     vue: ^2.7.14
     vue-cli-plugin-ant-design: ^1.0.1


### PR DESCRIPTION
## why?

1. There are too many courses with similar course names, causing lots of students to choose courses by mistake usually.

### such as 

 - completely equals

![723dd33bbc8790ba4df9d195f264e304.png](https://s2.loli.net/2023/06/27/BZm4lR6aC9JXOFw.png)

 - equals the class name in the plan

![image.png](https://s2.loli.net/2023/06/27/64NUDAzQZjFvVkY.png)

![image.png](https://s2.loli.net/2023/06/27/Mmr1xZoOCBp795i.png)

2. Popularize the compilation rules of the course number of Shanghai University, so that more students can search for courses based on the course number

## how?

 - Added the course property on lots of positions

![image.png](https://s2.loli.net/2023/06/27/47W3tvqdixyFJPn.png)
![image.png](https://s2.loli.net/2023/06/27/WUuwH5rEqMfAzPC.png)
![image.png](https://s2.loli.net/2023/06/27/UpPrR3Skzcm7sHN.png)
![image.png](https://s2.loli.net/2023/06/27/jkJnRtqUsPZAwFz.png)

## anticipation?

 - Add lookup condition with course properties
 - ...
