### PR TITLE
fix(ui): filter college with empty name

### DIFF
--- a/src/mixins/common/getCourseClassList.js
+++ b/src/mixins/common/getCourseClassList.js
@@ -2,7 +2,7 @@ import { getCollegesList, getMajorsList, getLessonPropertiesList } from "shu-cou
 
 export const GetCourseClassListMixin = {
   methods: {
-    getCollegesList: (p) => getCollegesList(p),
+    getCollegesList: (p) => getCollegesList(p).filter((v) => v.name !== ""),
     getMajorsList: (v, p) => getMajorsList(v, p),
     getLessonPropertiesList: () => getLessonPropertiesList(),
   }


### PR DESCRIPTION
This PR is to fix the minor ui problem appearing like this:
![image](https://github.com/shuosc/shu-course-number-parser/assets/68262945/699e1dc2-53a0-4157-b3d0-1437236be54d)
As discussed in <https://github.com/shuosc/shu-course-number-parser/issues/3>, the issue should be fixed in this repo.